### PR TITLE
Fix case sensitivity in willTopic option

### DIFF
--- a/ios/Mqtt.m
+++ b/ios/Mqtt.m
@@ -158,7 +158,7 @@
                            user:[self.options valueForKey:@"user"]
                            pass:[self.options valueForKey:@"pass"]
                            will:[self.options[@"will"] boolValue]
-                      willTopic:[self.options valueForKey:@"willTopic"]
+                      willTopic:[self.options valueForKey:@"willtopic"]
                         willMsg:willMsg
                         willQos:(MQTTQosLevel)[self.options[@"willQos"] intValue]
                  willRetainFlag:[self.options[@"willRetainFlag"] boolValue]

--- a/sp-react-native-mqtt.podspec
+++ b/sp-react-native-mqtt.podspec
@@ -15,4 +15,5 @@ Pod::Spec.new do |s|
   s.platform = :ios, "8.0"
 
   s.dependency "React"
+  s.dependency "MQTTClient"
 end


### PR DESCRIPTION
I have found out that in iOS, when config for LWT, the broker rejected. I have deep dived into the native codes and found out that I just have to change this line of code in ios/Mqtt.m file:

`                     willTopic:[self.options valueForKey:@"willTopic"]
`
into

`                     willTopic:[self.options valueForKey:@"willtopic"]
`
This works perferctly for both iOS and Android. Android already has been working well but I just tested it out on both platform.

Thanks.